### PR TITLE
Fix Airflow 3.x BashOperator import and install standard provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ ENV CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints
 
 RUN uv venv /home/airflow/.venv
 RUN uv pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
+RUN uv pip install apache-airflow-providers-standard
 RUN uv pip install pyspark==4.0.1 'pyspark[sql]==4.0.1'
 RUN uv pip install ruff
 RUN uv pip install jupyterlab

--- a/airflow/dags/generate_customer_marketing_metrics.py
+++ b/airflow/dags/generate_customer_marketing_metrics.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from airflow.decorators import dag
-from airflow.operators.bash import BashOperator
+from airflow.providers.standard.operators.bash import BashOperator
 
 default_args = {
     "owner": "airflow",


### PR DESCRIPTION
In Airflow 3.0+, BashOperator was moved from the core package to apache-airflow-providers-standard. The old import path (airflow.operators.bash) causes an ImportError when Airflow parses the DAG, preventing the DAG from being triggered.

- Update import to: airflow.providers.standard.operators.bash
- Add apache-airflow-providers-standard to Dockerfile

https://claude.ai/code/session_01LoibD2Wr73jZuQkJ6gYfak