### PR TITLE
Fix JAVA_HOME for ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     procps \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+# Dynamically set Java home for amd64/arm64
+RUN ln -s /usr/lib/jvm/java-17-openjdk-$(dpkg --print-architecture) /usr/lib/jvm/default-java
+ENV JAVA_HOME=/usr/lib/jvm/default-java
 ENV PATH=$JAVA_HOME/bin:$PATH
 
 # Install Spark 


### PR DESCRIPTION
**Title:**
**Fix JAVA_HOME for ARM64 (Mac M-series) architecture**

**Description:**
This PR fixes an issue where PySpark failed to initialize on systems using ARM64 architecture (such as Mac M1/M2/M3/M4/M5 chips) due to a hardcoded **JAVA_HOME** path in the Dockerfile.

**Changes:**
- Updated Dockerfile to dynamically locate the OpenJDK path using dpkg --print-architecture instead of hardcoding amd64.
- Ensured a consistent symlink at /usr/lib/jvm/default-java to point to the correct architecture-specific Java installation.

**Why this is needed:** 
Without this change, the airflow standalone services and Jupyter notebooks fail to start PySpark sessions on Mac M-series machines because the Java gateway process cannot be found at the previous hardcoded path.

**Verification:**

- Built the image using docker compose up --build. 

- Verified that the IPython startup scripts (01-spark-init.py) successfully create a Spark session on an ARM64 host.

- Confirmed the %%sql magic is working correctly in Jupyter Lab.